### PR TITLE
Add symbol "⊛" (Circled Asterisk Operator)

### DIFF
--- a/defaults/math.json
+++ b/defaults/math.json
@@ -155,6 +155,11 @@
     "body": "⊗"
   },
   {
+    "label": "o*",
+    "description": "⊛",
+    "body": "⊛"
+  },
+  {
     "label": "o/",
     "description": "⊘",
     "body": "⊘"


### PR DESCRIPTION
Unicode version of the `<*>` operator from the class `Applicative` in Haskell